### PR TITLE
Fixed deprecated pymodbus functions and fixed Power unit used

### DIFF
--- a/hoymiles_dtu_client.py
+++ b/hoymiles_dtu_client.py
@@ -30,9 +30,9 @@ class HoymilesDtuClient:
                 host=self.host,
                 port=self.port,
                 timeout=self.connection_timeout,
-                retry_on_empty=self.retry_on_empty,
-                retries=self.retries,
-                delay_on_connect=self.delay_on_connect
+#                retry_on_empty=self.retry_on_empty,
+                retries=self.retries
+#                delay_on_connect=self.delay_on_connect
             )
         
         if not self.client.connected:
@@ -89,7 +89,7 @@ class HoymilesDtuClient:
             # Add small delay between requests to avoid overwhelming DTU
             await asyncio.sleep(0.1)
             
-            result = await self.client.read_holding_registers(address, count)
+            result = await self.client.read_holding_registers(address, count=count)
             
             if result.isError():
                 raise ModbusException(f"Error reading address {hex(address)}: {result}")

--- a/sensor.py
+++ b/sensor.py
@@ -64,7 +64,7 @@ class HoymilesStationPowerSensor(SensorEntity):
         _LOGGER.debug(f"Fetching current power for station {self._sid}")
         power = await self._client.get_total_power()
         _LOGGER.debug(f"Received power data for station {self._sid}: {power/1000} kW")
-        self._state = float(power/1000)
+        self._state = float(power)
 
 
 class HoymilesStationDailyEnergySensor(SensorEntity):


### PR DESCRIPTION
I had issues with the 'retry_on_empty' and 'delay_on_connect' arguments being deprecated in the latest versions of pymodbus.

Further more, it seemed that the power unit was set incorrectly. It is now showing up correctly in my HA energy overview.